### PR TITLE
Add Dummy device

### DIFF
--- a/src/device/dummy.rs
+++ b/src/device/dummy.rs
@@ -1,0 +1,36 @@
+use crate::{
+    device::{Device, FeedCallback, MixContext, NativeSample},
+    error::SoundError,
+};
+use std::mem::size_of;
+
+pub struct DummySoundDevice {
+    callback: Box<FeedCallback>,
+    out_data: Vec<NativeSample>,
+    mix_buffer: Vec<(f32, f32)>,
+}
+
+impl DummySoundDevice {
+    pub fn new(buffer_len_bytes: u32, callback: Box<FeedCallback>) -> Result<Self, SoundError> {
+        let samples_per_channel = buffer_len_bytes as usize / size_of::<NativeSample>();
+        Ok(Self {
+            callback,
+            out_data: vec![Default::default(); samples_per_channel],
+            mix_buffer: vec![(0.0, 0.0); samples_per_channel],
+        })
+    }
+}
+
+impl Device for DummySoundDevice {
+    fn get_mix_context(&mut self) -> MixContext {
+        MixContext {
+            mix_buffer: self.mix_buffer.as_mut_slice(),
+            out_data: &mut self.out_data,
+            callback: &mut self.callback,
+        }
+    }
+
+    fn feed(&mut self) {
+        self.mix();
+    }
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -13,6 +13,9 @@ mod dsound;
 #[cfg(target_os = "linux")]
 mod alsa;
 
+// The dummy target works on all platforms
+mod dummy;
+
 // TODO: Make this configurable, for now its set to most commonly used sample rate of 44100 Hz.
 pub const SAMPLE_RATE: u32 = 44100;
 
@@ -85,6 +88,8 @@ pub(in crate) fn run_device(
     let mut device = dsound::DirectSoundDevice::new(buffer_len_bytes, callback)?;
     #[cfg(target_os = "linux")]
     let mut device = alsa::AlsaSoundDevice::new(buffer_len_bytes, callback)?;
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    let mut device = dummy::DummySoundDevice::new(buffer_len_bytes, callback)?;
     std::thread::spawn(move || loop {
         device.feed()
     });


### PR DESCRIPTION
This adds a no-op dummy device to make sure the build succeeds on unsupported targets like macos.